### PR TITLE
Stemming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-PROJECT_DIR=./stem
-BIN_NAME=myapp
+srcdir=./stem
+TARGET=myapp
 
-build:
-	go build -o $(BIN_NAME) $(PROJECT_DIR)
+build: install
+	go build -o $(TARGET) $(srcdir)
+
+install:
+	go mod tidy
 
 clean:
-	rm $(BIN_NAME)
+	rm $(TARGET)
 
-default:
-	build
-
-.PHONY: build clean
+.PHONY: build clean install

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+PROJECT_DIR=./stem
+BIN_NAME=myapp
+
+build:
+	go build -o $(BIN_NAME) $(PROJECT_DIR)
+
+clean:
+	rm $(BIN_NAME)
+
+default:
+	build
+
+.PHONY: build clean

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # Golang-Course
+## Task 1 — Stemming
+### Build
+To build the project use one of the following commands:
+```bash
+make
+```
+```bash
+make build
+```
+```bash
+go build -o myapp ./stem
+```
+### Run
+```bash
+./myapp -s <string for stemming>
+```
+Example
+```bash
+./myapp -s "i'll follow you as long as you are following me"
+```
+Output:
+```
+follow long
+```

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/AfoninaOlga/Golang-Course
+
+go 1.22.1
+
+require github.com/kljensen/snowball v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kljensen/snowball v0.9.0 h1:OpXkQBcic6vcPG+dChOGLIA/GNuVg47tbbIJ2s7Keas=
+github.com/kljensen/snowball v0.9.0/go.mod h1:OGo5gFWjaeXqCu4iIrMl5OYip9XUJHGOU5eSkPjVg2A=

--- a/stem/main.go
+++ b/stem/main.go
@@ -1,0 +1,15 @@
+package main
+
+import "fmt"
+
+func main() {
+	input := ParseInput()
+
+	if input == "" {
+		fmt.Println("Use \"-s\" flag to pass a string for stemming")
+	}
+
+	res := StemInput(input)
+
+	fmt.Println(res)
+}

--- a/stem/main.go
+++ b/stem/main.go
@@ -9,7 +9,12 @@ func main() {
 		fmt.Println("Use \"-s\" flag to pass a string for stemming")
 	}
 
-	res := StemInput(input)
+	res, err := StemInput(input)
+
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 
 	fmt.Println(res)
 }

--- a/stem/parse.go
+++ b/stem/parse.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"flag"
+)
+
+func ParseInput() (str string) {
+	flag.StringVar(&str, "s", "", "flag takes string for stemming")
+	flag.Parse()
+	return
+}

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"github.com/kljensen/snowball/english"
+	"regexp"
+	"strings"
+)
+
+func trimWord(word string) string {
+	re := regexp.MustCompile(`[^a-zA-Z]`)
+	return re.ReplaceAllString(word, "")
+}
+
+func StemInput(input string) string {
+	var result []string
+	stemmedWords := make(map[string]bool)
+	re := regexp.MustCompile(`-|'`)
+	for _, s := range strings.Fields(re.ReplaceAllString(input, " ")) {
+		s := english.Stem(trimWord(s), false)
+		if len(s) <= 2 || english.IsStopWord(s) || stemmedWords[s] {
+			continue
+		}
+		stemmedWords[s] = true
+		result = append(result, s)
+	}
+	return strings.Join(result, " ")
+}

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -1,18 +1,36 @@
 package main
 
 import (
+	"fmt"
 	"github.com/kljensen/snowball/english"
 	"strings"
 	"unicode"
 )
 
-func StemInput(input string) string {
+func checkWord(word string) (ok bool, err error) {
+	ok = true
+	err = nil
+
+	for _, c := range word {
+		if !unicode.Is(unicode.Latin, c) {
+			ok = false
+			err = fmt.Errorf("unknown letter: %c", c)
+		}
+	}
+	return
+}
+
+func StemInput(input string) (string, error) {
 	var result []string
 	stemmedWords := make(map[string]bool)
 	f := func(c rune) bool {
 		return !unicode.IsLetter(c)
 	}
 	for _, s := range strings.FieldsFunc(input, f) {
+		ok, err := checkWord(s)
+		if !ok {
+			return strings.Join(result, " "), err
+		}
 		s = english.Stem(s, false)
 		if len(s) <= 2 || english.IsStopWord(s) || stemmedWords[s] {
 			continue
@@ -20,5 +38,5 @@ func StemInput(input string) string {
 		stemmedWords[s] = true
 		result = append(result, s)
 	}
-	return strings.Join(result, " ")
+	return strings.Join(result, " "), nil
 }

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -14,7 +14,7 @@ func trimWord(word string) string {
 func StemInput(input string) string {
 	var result []string
 	stemmedWords := make(map[string]bool)
-	re := regexp.MustCompile(`-|'`)
+	re := regexp.MustCompile(`[-'.,!?:;]`)
 	for _, s := range strings.Fields(re.ReplaceAllString(input, " ")) {
 		s := english.Stem(trimWord(s), false)
 		if len(s) <= 2 || english.IsStopWord(s) || stemmedWords[s] {

--- a/stem/stem.go
+++ b/stem/stem.go
@@ -2,21 +2,18 @@ package main
 
 import (
 	"github.com/kljensen/snowball/english"
-	"regexp"
 	"strings"
+	"unicode"
 )
-
-func trimWord(word string) string {
-	re := regexp.MustCompile(`[^a-zA-Z]`)
-	return re.ReplaceAllString(word, "")
-}
 
 func StemInput(input string) string {
 	var result []string
 	stemmedWords := make(map[string]bool)
-	re := regexp.MustCompile(`[-'.,!?:;]`)
-	for _, s := range strings.Fields(re.ReplaceAllString(input, " ")) {
-		s := english.Stem(trimWord(s), false)
+	f := func(c rune) bool {
+		return !unicode.IsLetter(c)
+	}
+	for _, s := range strings.FieldsFunc(input, f) {
+		s = english.Stem(s, false)
 		if len(s) <= 2 || english.IsStopWord(s) || stemmedWords[s] {
 			continue
 		}


### PR DESCRIPTION
Добавлена реализация CLI приложения для стемминга.

- Для простоты определения стоп-слов используется [функциональность](https://github.com/kljensen/snowball/blob/98e7b6e10cca8489481be24eaabcea4b5c2021f8/english/common.go#L206) пакета `snowball`. Также отбрасываются слова длины ≤2.
- Строка разделяется по символам, отличным от букв. То есть дефисы и апострофы разделяют слово на два.
- Если в слове встречается символ, отличный от латиницы, выводится ошибка `unknow letter: [символ]`